### PR TITLE
Use by_row from purrrlyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ LazyData: true
 Imports:
     dplyr,
     purrr,
+    purrrlyr,
     tidyr,
     htmltools,
     DistributionUtils,
@@ -37,7 +38,7 @@ Suggests:
     gapminder,
     housingData,
     packagedocs
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1
 URL: https://github.com/hafen/trelliscopejs
 BugReports: https://github.com/hafen/trelliscopejs/issues
 VignetteBuilder: packagedocs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # trelliscopejs 0.1
 
+- Use `by_row()` from purrrlyr (0.1.8)
 - Use webshot for thumbnails and don't create thumbnails by default (0.1.8)
 - Update and add new tidyverse functions (0.1.7)
 - Update to trelliscopejs-lib 0.1.15 (polyfills for older browser support) (0.1.6)

--- a/R/facet_trelliscope.R
+++ b/R/facet_trelliscope.R
@@ -121,7 +121,7 @@ print.facet_trelliscope <- function(x, ...) {
   }
 
   panels <- (data %>%
-    purrr::by_row(~ make_plot_obj(unnest(.x[c(facet_cols, "data")]),
+    purrrlyr::by_row(~ make_plot_obj(unnest(.x[c(facet_cols, "data")]),
       as_plotly = attrs$as_plotly, plotly_args = attrs$plotly_args),
       .labels = FALSE))[[1]]
   names(panels) <- cog_df$panelKey # nolint

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -150,7 +150,7 @@ pmap_plot <- function(.l, .f, ...) {
 #' }
 #' @export
 by_row_plot <- function(.d, ..f, .to = "panel") {
-  res <- purrr::by_row(.d = .d, ..f = ..f, .to = .to)
+  res <- purrrlyr::by_row(.d = .d, ..f = ..f, .to = .to)
   class(res[[.to]]) <- c("trelliscope_panels", "list")
   res
 }
@@ -287,7 +287,7 @@ by_row_cog <- function(.d, ..f, .to = NULL) {
       .to <- "cogs"
     }
   }
-  res <- purrr::by_row(.d = .d, ..f = ..f, .to = .to)
+  res <- purrrlyr::by_row(.d = .d, ..f = ..f, .to = .to)
   class(res[[.to]]) <- c("trelliscope_cogs", "list")
   res
 }


### PR DESCRIPTION
The latest version of purrr removed the `by_row()` function and moved it to `purrrlyr`. Because trelliscopejs is not no CRAN I did this unconditionally.

I re-ran roxygen, but did not commit the changes in `man/*` as I wanted to keep the diff small.