### PR TITLE
Failed histogram breaks calculation

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -239,7 +239,7 @@ get_cog_distributions <- function(cogdf, cat_cutoff = 5000) {
         )
       )
       res$log_default <- FALSE
-      if (!is.nan(skw) && skw > 1.5 && all(x >= 0, na.rm = TRUE)) {
+      if (!is.nan(skw) && skw > 1.5 && all(x >= 0, na.rm = TRUE) && length(x[x > 0]) > 1) {
         # log <- TRUE
         x <- x[x > 0]
         x2 <- log10(x)


### PR DESCRIPTION
## What was done :  
Addresses #55 

This is a simple fix to avoid proceeding into the `if` closure for cases where there would be only one value greater than 0, causing an error when attempting to generate a histogram.  

Build is successful on both my work and local systems: 
Win 10 x64 R 3.4.1
and Win 7 x64 R 3.4.3  

I tried `trelliscope()` on both the reproducible example provided by @ataustin and a much larger project (~30 displays, many thousands of panels). Both rendered successfully without error.  

For reference, this is the example I tried:  
```r
library(ggplot2)
library(tidyr)
library(dplyr)
library(trelliscopejs)

df <- data.frame(group = letters[1:10],
                 val1  = rep(c(0, 0.9), times = c(9, 1))
                 )

df %>%
  group_by(group) %>%
  nest(.key = "data") %>%
  mutate(panel = map_plot(data, function(x) ggplot(x, aes(val1)) + geom_histogram())) %>%
  trelliscope(name = "test",
              path = "output")
```  

## Notes :  
- I did not performance test `get_cog_distributions()`, though I'm happy to do that and provide the results here if needed.  