### PR TITLE
Remove margin from knitr output

### DIFF
--- a/inst/htmlwidgets/trelliscopejs_widget.js
+++ b/inst/htmlwidgets/trelliscopejs_widget.js
@@ -26,8 +26,8 @@ HTMLWidgets.widget({
         el.appendChild(dv);
 
         if (x.in_knitr) {
-          el.style.marginTop = '30px';
-          el.style.marginBottom = '30px';
+          el.style.marginTop = '0px';
+          el.style.marginBottom = '0px';
         }
 
         var scrpt = document.createElement('script');


### PR DESCRIPTION
First off, this package is awesome. Ive made this pull request because there is a small issue when using it with flexdashboard.

When using this package with flexdashboard the presence of a margin causes the bottom bar not to be visible, and removes a core part of the functionality. Changing this fixes the issue.

Is there any reason why there is a 30px margin?

Best

Simon