### PR TITLE
Move cognostics class to front

### DIFF
--- a/R/cog.R
+++ b/R/cog.R
@@ -250,7 +250,7 @@ as_cognostics <- function(x, cond_cols, key_col = NULL, cog_desc = NULL,
     x[na_cogs] <- NULL
   }
 
-  class(x) <- c(class(x), "cognostics")
+  class(x) <- c("cognostics", class(x))
   x
 }
 


### PR DESCRIPTION
This fixes this problem: 

```
 > trelliscope(mpg_cog, name = "city_vs_highway_mpg", nrow = 1, ncol = 2)
  Error: Input must be a vector, not a `grouped_df/tbl_df/tbl/data.frame/cognostics` object.
  Backtrace:
      █
   1. ├─trelliscopejs::trelliscope(...)
   2. ├─trelliscopejs:::trelliscope.data.frame(...)
   3. │ └─trelliscopejs:::cog_df_info(...)
   4. │   └─dplyr::bind_cols(cogs)
   5. │     └─vctrs::vec_cbind(!!!dots)
   6. └─vctrs:::stop_scalar_type(...)
   7.   └─vctrs:::stop_vctrs(msg, "vctrs_error_scalar_type", actual = x)
  Execution halted
```

however it's not enough to make the package pass against dplyr 1.0.0 which will be released on May 15. 

What I currently see: 

```
==> devtools::test()

Loading trelliscopejs
Testing trelliscopejs
✓ |  OK F W S | Context
x |   0 1 224   | trelliscope [1.8 s]
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:12: warning: examples run without barfing
Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
  Consider 'structure(list(), *)' instead.

test-trelliscope.R:22: error: examples run without barfing
cogdf must be a cognostics object - call as_cognostics() to cast it as
       such.
Backtrace:
  9. trelliscopejs::trelliscope(., name = "city_vs_highway_mpg", thumb = FALSE)
 11. trelliscopejs::write_display_obj(...) R/trelliscope.R:142:2
 12. trelliscopejs::stop_nice(...) R/json_writers.R:192:2
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

══ Results ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 1.9 s

OK:       0
Failed:   1
Warnings: 224
Skipped:  0
```