### PR TITLE
Added relative path checking in knitr environment.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     covr,
     gapminder,
     housingData
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 URL: https://github.com/hafen/trelliscopejs
 BugReports: https://github.com/hafen/trelliscopejs/issues
 VignetteBuilder: knitr

--- a/R/abs-path-checking.R
+++ b/R/abs-path-checking.R
@@ -1,5 +1,6 @@
 # The following code was taken directly from the {xfun} package. It is
 # licensed under the MIT license. The copyright holder is Yihui Xie.
+# See https://github.com/yihui/xfun for the package and details.
 
 is_abs_path <- function (x) {
     if (is_unix())

--- a/R/abs-path-checking.R
+++ b/R/abs-path-checking.R
@@ -1,0 +1,27 @@
+# The following code was taken directly from the {xfun} package. It is
+# licensed under the MIT license. The copyright holder is Yihui Xie.
+
+is_abs_path <- function (x) {
+    if (is_unix())
+        grepl("^[/~]", x)
+    else !same_path(x, file.path(".", x))
+}
+
+same_path <- function (p1, p2, ...) {
+    normalize_path(p1, ...) == normalize_path(p2, ...)
+}
+
+normalize_path <- function (x, winslash = "/", must_work = FALSE) {
+    res = normalizePath(x, winslash = winslash, mustWork = must_work)
+    if (is_windows())
+        res[is.na(x)] = NA
+    res
+}
+
+is_windows <- function () {
+  .Platform$OS.type == "windows"
+}
+
+is_unix <- function () {
+  .Platform$OS.type == "unix"
+}

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -101,8 +101,9 @@ resolve_app_params <- function(path, self_contained, jsonp, split_sig, name, gro
   # if outside knitr, config.jsonp will always be available to index.html inside appfiles
   config_path <- paste0("appfiles/config.json", ifelse(jsonp, "p", ""))
   if (in_knitr || in_shiny && !self_contained) {
-    if (!grepl("^[A-Za-z0-9_]", orig_path))
+    if (is_abs_path(orig_path)) {
       stop_nice("Path for trelliscope output while inside knitr or Shiny must be relative.")
+    }
     if (in_shiny) {
       if (!grepl("^www/", orig_path))
         stop_nice("Path for trelliscope output while inside Shiny must go inside www/...")


### PR DESCRIPTION
This pull request addresses issue #104. A new file, `abs-path-checking.R` takes functionality from the {xfun} package (with proper attribution at the beginning of the file) and uses the `is_abs_path()` function to see if the path is relative inside knitr.