### PR TITLE
`ggplot_add()` method consistency

### DIFF
--- a/R/facet_trelliscope.R
+++ b/R/facet_trelliscope.R
@@ -99,7 +99,7 @@ facet_trelliscope <- function(
 }
 
 #' @export
-ggplot_add.facet_trelliscope <- function(object, plot, object_name) {
+ggplot_add.facet_trelliscope <- function(object, plot, ...) {
   attr(plot, "trelliscope") <- object[
     c("facets", "facet_cols", "name", "group",
       "desc", "md_desc", "height", "width", "inputs", "state", "jsonp", "self_contained", "google_analytics_id",


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue was that we've updated `ggplot_add()` to have the `...` argument. Ideally, methods should also have `...` for consistency, which is what this PR aims to do.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
